### PR TITLE
Add Stripe payment support

### DIFF
--- a/backend/src/application/service/payment.service.ts
+++ b/backend/src/application/service/payment.service.ts
@@ -6,7 +6,7 @@ export class PaymentService {
   private stripe: Stripe;
   constructor(private readonly repository: PaymentRepository) {
     const key = process.env.STRIPE_SECRET_KEY as string;
-    this.stripe = new Stripe(key, { apiVersion: '2022-11-15' });
+    this.stripe = new Stripe(key);
   }
 
   async createPaymentIntent(cartId: number): Promise<string | null> {
@@ -42,6 +42,7 @@ export class PaymentService {
       trackingNum,
       status: 'purchased',
       amount,
+      paymentIntentId
     });
   }
 }

--- a/backend/src/application/service/payment.service.ts
+++ b/backend/src/application/service/payment.service.ts
@@ -1,0 +1,47 @@
+import Stripe from 'stripe';
+import { randomUUID } from 'crypto';
+import { PaymentRepository } from '../../domain/repositories/payment.repository';
+
+export class PaymentService {
+  private stripe: Stripe;
+  constructor(private readonly repository: PaymentRepository) {
+    const key = process.env.STRIPE_SECRET_KEY as string;
+    this.stripe = new Stripe(key, { apiVersion: '2022-11-15' });
+  }
+
+  async createPaymentIntent(cartId: number): Promise<string | null> {
+    const cart = await this.repository.getActiveCartById(cartId);
+    if (!cart) return null;
+    const amount = Math.round(cart.getTotalAmount() * 100);
+    const intent = await this.stripe.paymentIntents.create({
+      amount,
+      currency: 'cad',
+    });
+    await this.repository.updateCartPaymentIntent(cartId, intent.id);
+    await this.repository.updateCartStatus(cartId, 'pending');
+    return intent.client_secret ?? null;
+  }
+
+  async handleWebhook(payload: Buffer | string, signature: string | undefined, secret: string): Promise<void> {
+    if (!signature) throw new Error('Missing signature');
+    const event = this.stripe.webhooks.constructEvent(payload, signature, secret);
+    if (event.type === 'payment_intent.succeeded') {
+      const intent = event.data.object as Stripe.PaymentIntent;
+      await this.processSuccess(intent.id, intent.amount);
+    }
+  }
+
+  private async processSuccess(paymentIntentId: string, amount: number) {
+    const cart = await this.repository.getCartByPaymentIntentId(paymentIntentId);
+    if (!cart || !cart.user || !cart.id) return;
+    await this.repository.updateCartStatus(cart.id, 'purchased');
+    const trackingNum = randomUUID();
+    await this.repository.createTransaction({
+      userId: cart.user.id as number,
+      cartId: cart.id,
+      trackingNum,
+      status: 'purchased',
+      amount,
+    });
+  }
+}

--- a/backend/src/domain/entities/cart.entity.ts
+++ b/backend/src/domain/entities/cart.entity.ts
@@ -43,7 +43,8 @@ export class Cart {
   }
 
   getTotalAmount():number {
-    return this._cartItems.reduce((sum, item) => sum + item.getSubTotal(), 0);
+    const total = this._cartItems.reduce((sum, item) => sum + item.getSubTotal(), 0);
+    return Math.round(total * 100) / 100;
   }
 
   toPlainObject() {

--- a/backend/src/domain/entities/transaction.entity.ts
+++ b/backend/src/domain/entities/transaction.entity.ts
@@ -1,0 +1,43 @@
+export class Transaction {
+  constructor(
+    private readonly _id: number,
+    private readonly _userId: number,
+    private readonly _cartId: number,
+    private readonly _trackingNum: string,
+    private _status: 'purchased' | 'cancel',
+    private readonly _amount: number,
+    private readonly _createdAt: string,
+    private _updatedAt: string,
+  ) {}
+
+  get id(): number { return this._id; }
+  get userId(): number { return this._userId; }
+  get cartId(): number { return this._cartId; }
+  get trackingNum(): string { return this._trackingNum; }
+  get status(): 'purchased' | 'cancel' { return this._status; }
+  get amount(): number { return this._amount; }
+  get createdAt(): string { return this._createdAt; }
+  get updatedAt(): string { return this._updatedAt; }
+
+  updateStatus(status: 'purchased' | 'cancel') {
+    this._status = status;
+    this.touchUpdatedAt();
+  }
+
+  private touchUpdatedAt() {
+    this._updatedAt = new Date().toISOString();
+  }
+
+  toPlainObject() {
+    return {
+      id: this._id,
+      userId: this._userId,
+      cartId: this._cartId,
+      trackingNum: this._trackingNum,
+      status: this._status,
+      amount: this._amount,
+      createdAt: this._createdAt,
+      updatedAt: this._updatedAt,
+    };
+  }
+}

--- a/backend/src/domain/repositories/payment.repository.ts
+++ b/backend/src/domain/repositories/payment.repository.ts
@@ -1,0 +1,17 @@
+import { Cart } from '../entities/cart.entity';
+
+export interface CreateTransactionInput {
+  userId: number;
+  cartId: number;
+  trackingNum: string;
+  status: 'purchased' | 'cancel';
+  amount: number;
+}
+
+export interface PaymentRepository {
+  getActiveCartById(cartId: number): Promise<Cart | null>;
+  updateCartPaymentIntent(cartId: number, paymentIntentId: string): Promise<void>;
+  updateCartStatus(cartId: number, status: 'pending' | 'purchased'): Promise<void>;
+  getCartByPaymentIntentId(paymentIntentId: string): Promise<Cart | null>;
+  createTransaction(data: CreateTransactionInput): Promise<void>;
+}

--- a/backend/src/domain/repositories/payment.repository.ts
+++ b/backend/src/domain/repositories/payment.repository.ts
@@ -6,6 +6,7 @@ export interface CreateTransactionInput {
   trackingNum: string;
   status: 'purchased' | 'cancel';
   amount: number;
+  paymentIntentId: string;
 }
 
 export interface PaymentRepository {

--- a/backend/src/infrastructure/repositories/payment.repository.ts
+++ b/backend/src/infrastructure/repositories/payment.repository.ts
@@ -137,8 +137,8 @@ const createTransaction = async (data: CreateTransactionInput): Promise<void> =>
   try {
     await client.connect();
     await client.query(
-      `INSERT INTO transaction (user_id, cart_id, tracking_num, status, amount, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
-      [data.userId, data.cartId, data.trackingNum, data.status, data.amount]
+      `INSERT INTO transaction (user_id, cart_id, tracking_num, status, amount, payment_intent_id, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [data.userId, data.cartId, data.trackingNum, data.status, data.amount, data.paymentIntentId]
     );
   } finally {
     await client.end();

--- a/backend/src/infrastructure/repositories/payment.repository.ts
+++ b/backend/src/infrastructure/repositories/payment.repository.ts
@@ -1,0 +1,154 @@
+import { createClient } from '../database/dbClient';
+import { PaymentRepository, CreateTransactionInput } from '../../domain/repositories/payment.repository';
+import { Cart } from '../../domain/entities/cart.entity';
+import { CartItem } from '../../domain/entities/cartItem.entity';
+import { Product } from '../../domain/entities/product.entity';
+import { Category } from '../../domain/entities/category.entity';
+import { User } from '../../domain/entities/user.entity';
+
+const mapRowToCart = (row: any): Cart => {
+  return new Cart(
+    row.id,
+    row.status,
+    row.created_at,
+    row.updated_at,
+    row.shipping_address
+  );
+};
+
+const mapRowToCartItem = (row: any): CartItem => {
+  return new CartItem(
+    row.id,
+    row.quantity,
+    row.created_at,
+    row.updated_at
+  );
+};
+
+const getActiveCartById = async (cartId: number): Promise<Cart | null> => {
+  const client = createClient();
+  try {
+    await client.connect();
+    const cartRes = await client.query(
+      `SELECT c.*, u.id as "userId", u.firstname as "firstName", u.lastname as "lastName", u.email, u.password, u.role, u.created_at as "userCreatedAt", u.updated_at as "userUpdatedAt" FROM cart c JOIN "user" u ON c.user_id = u.id WHERE c.id = $1 AND c.status = 'active' LIMIT 1`,
+      [cartId]
+    );
+    if (cartRes.rows.length === 0) return null;
+    const row = cartRes.rows[0];
+    const cart = mapRowToCart(row);
+    const user = new User(row.userId, row.firstName, row.lastName, row.email, row.password, row.role, row.userCreatedAt, row.userUpdatedAt);
+    cart.setUser(user);
+    const itemsRes = await client.query(
+      `SELECT ci.id AS "cartItemId", ci.quantity, ci.created_at, ci.updated_at,
+              p.id AS "productId", p.product_name, p.price, p.main_image, p.description,
+              p.discount_percentage, p.rating, p.sku,
+              cat.id AS "categoryId", cat.category_name, cat.description AS category_description,
+              cat.image AS category_image, cat.created_at AS category_created_at, cat.updated_at AS category_updated_at
+         FROM cart_item ci
+         JOIN product p ON ci.product_id = p.id
+         JOIN category cat ON p.category_id = cat.id
+         WHERE ci.cart_id = $1`,
+      [cartId]
+    );
+    const cartItems = itemsRes.rows.map(row => {
+      const category = new Category(
+        row.categoryId,
+        row.category_name,
+        row.category_description,
+        row.category_image,
+        row.category_created_at,
+        row.category_updated_at
+      );
+      const product = new Product(
+        row.productId,
+        row.product_name,
+        category,
+        row.price,
+        row.main_image,
+        row.description,
+        row.discount_percentage,
+        row.rating,
+        row.sku,
+        row.created_at,
+        row.updated_at
+      );
+      return new CartItem(
+        row.cartItemId,
+        row.quantity,
+        row.created_at,
+        row.updated_at,
+        product
+      );
+    });
+    cart.setCartItems(cartItems);
+    return cart;
+  } finally {
+    await client.end();
+  }
+};
+
+const updateCartPaymentIntent = async (cartId: number, paymentIntentId: string): Promise<void> => {
+  const client = createClient();
+  try {
+    await client.connect();
+    await client.query(
+      `UPDATE cart SET payment_intent_id = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2`,
+      [paymentIntentId, cartId]
+    );
+  } finally {
+    await client.end();
+  }
+};
+
+const updateCartStatus = async (cartId: number, status: 'pending' | 'purchased'): Promise<void> => {
+  const client = createClient();
+  try {
+    await client.connect();
+    await client.query(
+      `UPDATE cart SET status = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2`,
+      [status, cartId]
+    );
+  } finally {
+    await client.end();
+  }
+};
+
+const getCartByPaymentIntentId = async (paymentIntentId: string): Promise<Cart | null> => {
+  const client = createClient();
+  try {
+    await client.connect();
+    const cartRes = await client.query(
+      `SELECT c.*, u.id as "userId", u.firstname as "firstName", u.lastname as "lastName", u.email, u.password, u.role, u.created_at as "userCreatedAt", u.updated_at as "userUpdatedAt" FROM cart c JOIN "user" u ON c.user_id = u.id WHERE c.payment_intent_id = $1 LIMIT 1`,
+      [paymentIntentId]
+    );
+    if (cartRes.rows.length === 0) return null;
+    const row = cartRes.rows[0];
+    const cart = mapRowToCart(row);
+    const user = new User(row.userId, row.firstName, row.lastName, row.email, row.password, row.role, row.userCreatedAt, row.userUpdatedAt);
+    cart.setUser(user);
+    return cart;
+  } finally {
+    await client.end();
+  }
+};
+
+const createTransaction = async (data: CreateTransactionInput): Promise<void> => {
+  const client = createClient();
+  try {
+    await client.connect();
+    await client.query(
+      `INSERT INTO transaction (user_id, cart_id, tracking_num, status, amount, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+      [data.userId, data.cartId, data.trackingNum, data.status, data.amount]
+    );
+  } finally {
+    await client.end();
+  }
+};
+
+export default {
+  getActiveCartById,
+  updateCartPaymentIntent,
+  updateCartStatus,
+  getCartByPaymentIntentId,
+  createTransaction,
+} as PaymentRepository;

--- a/backend/src/interfaces/http/controllers/payment.controller.ts
+++ b/backend/src/interfaces/http/controllers/payment.controller.ts
@@ -1,0 +1,36 @@
+import { Request, Response } from 'express';
+import { PaymentService } from '../../../application/service/payment.service';
+
+export function createPaymentController(paymentService: PaymentService) {
+  return {
+    createPaymentIntent: async (req: Request, res: Response) => {
+      const cartId = parseInt(req.body.cartId);
+      if (isNaN(cartId)) {
+        res.status(400).json({ error: 'Invalid cartId' });
+        return;
+      }
+      try {
+        const clientSecret = await paymentService.createPaymentIntent(cartId);
+        if (!clientSecret) {
+          res.status(404).json({ error: 'Cart not found or inactive' });
+          return;
+        }
+        res.status(200).json({ clientSecret });
+      } catch (err) {
+        console.error(err);
+        res.status(500).json({ error: 'Failed to create payment intent' });
+      }
+    },
+    webhook: async (req: Request, res: Response) => {
+      const signature = req.headers['stripe-signature'] as string | undefined;
+      const secret = process.env.STRIPE_WEBHOOK_SECRET as string;
+      try {
+        await paymentService.handleWebhook(req.body, signature, secret);
+        res.status(200).send('ok');
+      } catch (err) {
+        console.error('Webhook Error:', err);
+        res.status(400).send('Webhook Error');
+      }
+    },
+  };
+}

--- a/backend/src/interfaces/http/routes/payment.routes.ts
+++ b/backend/src/interfaces/http/routes/payment.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { PaymentService } from '../../../application/service/payment.service';
+import paymentRepository from '../../../infrastructure/repositories/payment.repository';
+import { createPaymentController } from '../controllers/payment.controller';
+
+const paymentRouter = Router();
+
+const paymentService = new PaymentService(paymentRepository);
+const paymentController = createPaymentController(paymentService);
+
+paymentRouter.post('/create-payment-intent', paymentController.createPaymentIntent);
+
+export { paymentService, paymentController };
+export default paymentRouter;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -23,7 +23,7 @@ app.use(cors({
   origin: "http://localhost:5173", // React port
   credentials: true // allow cookie transfer
 }))
-app.post('/payment/webhook', express.raw({ type: 'application/json' }), paymentController.webhook)
+app.post('/webhook', express.raw({ type: 'application/json' }), paymentController.webhook)
 app.use(express.json());
 const SIGN_KEY = process.env.COOKIE_SIGN_KEY
 const ENCRYPT_KEY = process.env.COOKIE_ENCRYPT_KEY

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -13,6 +13,7 @@ import userRouter from './interfaces/http/routes/user.routes'
 import categoryRouter from './interfaces/http/routes/category.routes'
 import productRouter from './interfaces/http/routes/product.routes'
 import cartRouter from './interfaces/http/routes/cart.routes'
+import paymentRouter, { paymentController } from './interfaces/http/routes/payment.routes'
 
 // Create server
 const app = express()
@@ -22,6 +23,7 @@ app.use(cors({
   origin: "http://localhost:5173", // React port
   credentials: true // allow cookie transfer
 }))
+app.post('/payment/webhook', express.raw({ type: 'application/json' }), paymentController.webhook)
 app.use(express.json());
 const SIGN_KEY = process.env.COOKIE_SIGN_KEY
 const ENCRYPT_KEY = process.env.COOKIE_ENCRYPT_KEY
@@ -40,6 +42,7 @@ app.use('/user', userRouter);
 app.use('/category', categoryRouter);
 app.use('/product', productRouter)
 app.use('/cart', cartRouter)
+app.use('/payment', paymentRouter)
 
 // Fallback
 app.use((req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
- add payment integration service and controller
- handle Stripe webhooks
- store transactions in DB
- expose payment routes and mount router in server

## Testing
- `npx tsc`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b082a4488329939b39ebea6d468a