### PR TITLE
Refactor product tests

### DIFF
--- a/backend/src/integration/product/get.test.ts
+++ b/backend/src/integration/product/get.test.ts
@@ -69,6 +69,26 @@ describe('GET /product', () => {
     }
   ]
 
+  const expectProduct = (product: any, expected: any) => {
+    expect(product.id).toBe(expected.id);
+    expect(product.productName).toBe(expected.productName);
+    expect(product.price).toBe(expected.price);
+    expect(product.mainImage).toBe(expected.mainImage);
+    expect(product.description).toBe(expected.description);
+    expect(product.category.id).toBe(expected.category.id);
+    expect(product.category.categoryName).toBe(expected.category.categoryName);
+    expect(product.category.description).toBe(expected.category.description);
+    expect(product.category.image).toBe(expected.category.image);
+    expect(product.discountPercentage).toBe(expected.discountPercentage);
+    expect(product.rating).toBe(expected.rating);
+    expect(product.sku).toBe(expected.sku);
+
+    expect(product.category.createdAt).not.toBeNull();
+    expect(product.category.updatedAt).not.toBeNull();
+    expect(product.createdAt).not.toBeNull();
+    expect(product.updatedAt).not.toBeNull();
+  }
+
   // テスト用データを挿入
   beforeAll(async () => {
     await client.connect();  // データベースに接続
@@ -104,23 +124,7 @@ describe('GET /product', () => {
     for (let i = 0; i < resultList.length; i++) {
       const expected = resultList[i];
       const product = response.body[i];
-
-      expect(product.productName).toBe(expected.productName);
-      expect(product.price).toBe(expected.price);
-      expect(product.mainImage).toBe(expected.mainImage);
-      expect(product.description).toBe(expected.description);
-      expect(product.category.id).toBe(expected.category.id);
-      expect(product.category.categoryName).toBe(expected.category.categoryName);
-      expect(product.category.description).toBe(expected.category.description);
-      expect(product.category.image).toBe(expected.category.image);
-      expect(product.discountPercentage).toBe(expected.discountPercentage);
-      expect(product.rating).toBe(expected.rating);
-      expect(product.sku).toBe(expected.sku);
-
-      expect(product.category.createdAt).not.toBeNull();
-      expect(product.category.updatedAt).not.toBeNull();
-      expect(product.createdAt).not.toBeNull();
-      expect(product.updatedAt).not.toBeNull();
+      expectProduct(product, expected);
     }
   });
 
@@ -134,24 +138,7 @@ describe('GET /product', () => {
     for (let i = 0; i < expectedProducts.length; i++) {
       const product = response.body[i];
       const expected = expectedProducts[i];
-
-      expect(product.id).toBe(expected.id);
-      expect(product.productName).toBe(expected.productName);
-      expect(product.price).toBe(expected.price);
-      expect(product.mainImage).toBe(expected.mainImage);
-      expect(product.description).toBe(expected.description);
-      expect(product.category.id).toBe(expected.category.id);
-      expect(product.category.categoryName).toBe(expected.category.categoryName);
-      expect(product.category.description).toBe(expected.category.description);
-      expect(product.category.image).toBe(expected.category.image);
-      expect(product.discountPercentage).toBe(expected.discountPercentage);
-      expect(product.rating).toBe(expected.rating);
-      expect(product.sku).toBe(expected.sku);
-
-      expect(product.category.createdAt).not.toBeNull();
-      expect(product.category.updatedAt).not.toBeNull();
-      expect(product.createdAt).not.toBeNull();
-      expect(product.updatedAt).not.toBeNull();
+      expectProduct(product, expected);
     }
   });
 
@@ -162,24 +149,7 @@ describe('GET /product', () => {
 
     const product = response.body;
     const expected = resultList[0];
-
-    expect(product.id).toBe(expected.id);
-    expect(product.productName).toBe(expected.productName);
-    expect(product.price).toBe(expected.price);
-    expect(product.mainImage).toBe(expected.mainImage);
-    expect(product.description).toBe(expected.description);
-    expect(product.category.id).toBe(expected.category.id);
-    expect(product.category.categoryName).toBe(expected.category.categoryName);
-    expect(product.category.description).toBe(expected.category.description);
-    expect(product.category.image).toBe(expected.category.image);
-    expect(product.discountPercentage).toBe(expected.discountPercentage);
-    expect(product.rating).toBe(expected.rating);
-    expect(product.sku).toBe(expected.sku);
-
-    expect(product.category.createdAt).not.toBeNull();
-    expect(product.category.updatedAt).not.toBeNull();
-    expect(product.createdAt).not.toBeNull();
-    expect(product.updatedAt).not.toBeNull();
+    expectProduct(product, expected);
   });
 
   it('should return product by id', async () => {
@@ -189,24 +159,7 @@ describe('GET /product', () => {
 
     const product = response.body;
     const expected = resultList[0];
-
-    expect(product.id).toBe(expected.id);
-    expect(product.productName).toBe(expected.productName);
-    expect(product.price).toBe(expected.price);
-    expect(product.mainImage).toBe(expected.mainImage);
-    expect(product.description).toBe(expected.description);
-    expect(product.category.id).toBe(expected.category.id);
-    expect(product.category.categoryName).toBe(expected.category.categoryName);
-    expect(product.category.description).toBe(expected.category.description);
-    expect(product.category.image).toBe(expected.category.image);
-    expect(product.discountPercentage).toBe(expected.discountPercentage);
-    expect(product.rating).toBe(expected.rating);
-    expect(product.sku).toBe(expected.sku);
-
-    expect(product.category.createdAt).not.toBeNull();
-    expect(product.category.updatedAt).not.toBeNull();
-    expect(product.createdAt).not.toBeNull();
-    expect(product.updatedAt).not.toBeNull();
+    expectProduct(product, expected);
   });
 
   // テスト終了後にデータを削除

--- a/backend/src/integration/product/get.test.ts
+++ b/backend/src/integration/product/get.test.ts
@@ -69,26 +69,6 @@ describe('GET /product', () => {
     }
   ]
 
-  const expectProduct = (product: any, expected: any) => {
-    expect(product.id).toBe(expected.id);
-    expect(product.productName).toBe(expected.productName);
-    expect(product.price).toBe(expected.price);
-    expect(product.mainImage).toBe(expected.mainImage);
-    expect(product.description).toBe(expected.description);
-    expect(product.category.id).toBe(expected.category.id);
-    expect(product.category.categoryName).toBe(expected.category.categoryName);
-    expect(product.category.description).toBe(expected.category.description);
-    expect(product.category.image).toBe(expected.category.image);
-    expect(product.discountPercentage).toBe(expected.discountPercentage);
-    expect(product.rating).toBe(expected.rating);
-    expect(product.sku).toBe(expected.sku);
-
-    expect(product.category.createdAt).not.toBeNull();
-    expect(product.category.updatedAt).not.toBeNull();
-    expect(product.createdAt).not.toBeNull();
-    expect(product.updatedAt).not.toBeNull();
-  }
-
   // テスト用データを挿入
   beforeAll(async () => {
     await client.connect();  // データベースに接続
@@ -113,7 +93,7 @@ describe('GET /product', () => {
   // test
   it('should return all products', async () => {
     const response = await request(app).get('/product');
-    
+
     // ステータスコードが200であることを確認
     expect(response.status).toBe(200);
 
@@ -168,5 +148,25 @@ describe('GET /product', () => {
     await client.query('DELETE FROM "category"');
     await client.end();  // データベース接続を終了
   });
+
+  const expectProduct = (product: any, expected: any) => {
+    expect(product.id).toBe(expected.id);
+    expect(product.productName).toBe(expected.productName);
+    expect(product.price).toBe(expected.price);
+    expect(product.mainImage).toBe(expected.mainImage);
+    expect(product.description).toBe(expected.description);
+    expect(product.category.id).toBe(expected.category.id);
+    expect(product.category.categoryName).toBe(expected.category.categoryName);
+    expect(product.category.description).toBe(expected.category.description);
+    expect(product.category.image).toBe(expected.category.image);
+    expect(product.discountPercentage).toBe(expected.discountPercentage);
+    expect(product.rating).toBe(expected.rating);
+    expect(product.sku).toBe(expected.sku);
+
+    expect(product.category.createdAt).not.toBeNull();
+    expect(product.category.updatedAt).not.toBeNull();
+    expect(product.createdAt).not.toBeNull();
+    expect(product.updatedAt).not.toBeNull();
+  }
 });
 


### PR DESCRIPTION
## Summary
- remove repeated assertion code in `src/integration/product/get.test.ts`
- replace with helper function `expectProduct`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849af45676c8329a0704f9994c2b198